### PR TITLE
Added check for reads

### DIFF
--- a/src/stats/stats-total.js
+++ b/src/stats/stats-total.js
@@ -347,7 +347,7 @@ function updateTableRows(data) {
         const clapsPerViewsRatio =
           post.upvotes === 0 ? 0 : ((post.claps / post.views) * 100).toFixed(1);
         const fansPerReadsRatio =
-          post.upvotes === 0
+          (post.upvotes === 0 || post.reads === 0)
             ? 0
             : ((post.upvotes / post.reads) * 100).toFixed(1);
         claps.innerHTML = `


### PR DESCRIPTION
### Issue
In some cases, a user can clap for an article but not actually read it. An edge case is when the number of reads is 0 but the number of claps is non-zero. It shows the ratio as inifinity% in this case

![image](https://user-images.githubusercontent.com/40443639/126670144-2658fafd-977c-467d-bd9e-5ed0fd7b7620.png)

### Fix
If the number of reads is 0, the ratio is also 0

